### PR TITLE
docs: fix a few simple typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Code Files
 
 `./dml/NN` -the code of **Neural NetWorks**
 
-`./dml/LR` -**Logistic Regression**,actualy It's **softmax**
+`./dml/LR` -**Logistic Regression**,actually It's **softmax**
 
 `./dml/DT` -**Decision Tree** , CART algorithm
 
@@ -21,7 +21,7 @@ Code Files
 
 `./dml/KNN` -the **k-Nearest Neighbor** algorithm(kd-tree BBF implementing)
 
-`./dml/NB`  -the **naive Bayesian** support both  continous and descrete features
+`./dml/NB`  -the **naive Bayesian** support both  continuous and descrete features
 
 `./dml/SVM` -the basic binary **Support Vector Machine**
 

--- a/dml/CNN/CNN.py
+++ b/dml/CNN/CNN.py
@@ -5,7 +5,7 @@ from scipy.signal import convolve as conv
 from dml.tool import sigmoid,expand,showimage
 from numpy import rot90
 '''
-	this algorithm have refered to the DeepLearnToolBox(https://github.com/rasmusbergpalm/DeepLearnToolbox)
+	this algorithm have referred to the DeepLearnToolBox(https://github.com/rasmusbergpalm/DeepLearnToolbox)
 	also:[1]:"Notes on Convolutional Neural Networks" Jake Bouvrie 2006 - How to implement CNNs
 	I want to implement as [1] described,where the subsampling layer have sigmoid function
 	 but finally it does not converge,but I can pass the gradcheck!!

--- a/dml/DT/decisionTree.py
+++ b/dml/DT/decisionTree.py
@@ -29,7 +29,7 @@ class DTC:
 			so If your X have some string parameter,all thing will translate to string
 			in this situation,you can't have continuous parameter
 			so remember:
-			if you have continous parameter,DON'T PUT any STRING IN X  !!!!!!!!
+			if you have continuous parameter,DON'T PUT any STRING IN X  !!!!!!!!
 		'''
 		self.X=np.array(X).transpose()
 		self.y=np.array(y).flatten(1)

--- a/dml/LR/logisticRegression.py
+++ b/dml/LR/logisticRegression.py
@@ -12,7 +12,7 @@ class LRC:
 		X	-is a N*M matrix  
 		y	-is a M  vector 
 		lam	-is the parameter lambda for LR penalty
-		actualy it's a softmax......=.=
+		actually it's a softmax......=.=
 		but they are same when the class_number is 2
 		also see ufldl:
 		http://ufldl.stanford.edu/wiki/index.php/Softmax_Regression

--- a/dml/NB/naiveBayesian.py
+++ b/dml/NB/naiveBayesian.py
@@ -9,10 +9,10 @@ class NBC:
 	def __init__(self,X,y,Indicator=None):
 		'''
 		 X 			 a N*M matrix where M is the train case number
-		 			 should be number both continous and descret feature
+		 			 should be number both continuous and discreet feature
 		 y			 class label for classification
-		 Indicator 	 show whether the feature is continous(0) or descret(1)
-		             continous in default
+		 Indicator 	 show whether the feature is continuous(0) or discreet(1)
+		             continuous in default
 
 		'''
 		self.X=np.array(X)

--- a/dml/NN/neuralNetwork.py
+++ b/dml/NN/neuralNetwork.py
@@ -3,7 +3,7 @@
 	DeepLearnToolbox(https://github.com/rasmusbergpalm/DeepLearnToolbox)
 	I think the whole architecture of it is clear and easy to understand
 	so I copy it to python
-	I also recommand UFLDL(http://ufldl.stanford.edu/wiki/index.php/UFLDL_Tutorial)
+	I also recommend UFLDL(http://ufldl.stanford.edu/wiki/index.php/UFLDL_Tutorial)
 	to learn Neural Network
 	
 	TODO:SAE,DAE and so on

--- a/test/naiveBayesian/nb_test.py
+++ b/test/naiveBayesian/nb_test.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy as sp
 from dml.NB import NBC
 '''
-  Example of descret data from  <统计学习方法>
+  Example of discreet data from  <统计学习方法>
   S=0
   M=1
   L=2


### PR DESCRIPTION
There are small typos in:
- README.md
- dml/CNN/CNN.py
- dml/DT/decisionTree.py
- dml/LR/logisticRegression.py
- dml/NB/naiveBayesian.py
- dml/NN/neuralNetwork.py
- test/naiveBayesian/nb_test.py

Fixes:
- Should read `continuous` rather than `continous`.
- Should read `discreet` rather than `descret`.
- Should read `actually` rather than `actualy`.
- Should read `referred` rather than `refered`.
- Should read `recommend` rather than `recommand`.

Closes #2